### PR TITLE
Implements mostly correct speed adjustments for the Player in HubUtil

### DIFF
--- a/src/fps_hooks.rs
+++ b/src/fps_hooks.rs
@@ -8,21 +8,22 @@ pub fn vsync_count_hook(_: i32, method_info: OptionalMethod) {
         CURRENT_FPS = fps;
     }
 
-    match fps {
-        120 => call_original!(0, method_info), // hidden from menu, set via config---vsync 0 breaks everything...
-        60  => call_original!(1, method_info),
-        30  => call_original!(2, method_info),
-        _   => call_original!(2, method_info) // fallback to 30 fps if invalid setting
-    }
+    call_original!(
+        match fps {
+            120 => 0, // hidden from menu, set via config---vsync 0 breaks everything...
+            60  => 1,
+            30  => 2,
+            _   => 2, // fallback to 30 fps if invalid setting
+        },
+        method_info
+    );
 }
 
 fn speed_modifier() -> f32 {
-    unsafe {
-        let speed_mod = 30.0 / CURRENT_FPS as f32;
+    let speed_mod = 30.0 / unsafe { CURRENT_FPS } as f32;
 
-        // this ensures *most* of the other speed hooks work close to how they would at 30fps
-        return speed_mod * speed_mod;
-    }
+    // this ensures *most* of the other speed hooks work close to how they would at 30fps
+    return speed_mod * speed_mod;
 }
 
 // App.HubUtil$$get_PlayerMaxSpeed	7102a5e820	float App.HubUtil$$get_PlayerMaxSpeed(MethodInfo * method)	96

--- a/src/fps_hooks.rs
+++ b/src/fps_hooks.rs
@@ -7,23 +7,58 @@ pub fn vsync_count_hook(_: i32, method_info: OptionalMethod) {
     unsafe {
         CURRENT_FPS = fps;
     }
-    if fps == 60 {
-        call_original!(1, method_info);
-    } else {
-        call_original!(2, method_info)
+
+    match fps {
+        120 => call_original!(0, method_info), // hidden from menu, set via config---vsync 0 breaks everything...
+        60  => call_original!(1, method_info),
+        30  => call_original!(2, method_info),
+        _   => call_original!(2, method_info) // fallback to 30 fps if invalid setting
+    }
+}
+
+fn speed_modifier() -> f32 {
+    unsafe {
+        let speed_mod = 30.0 / CURRENT_FPS as f32;
+
+        // this ensures *most* of the other speed hooks work close to how they would at 30fps
+        return speed_mod * speed_mod;
     }
 }
 
 // App.HubUtil$$get_PlayerMaxSpeed	7102a5e820	float App.HubUtil$$get_PlayerMaxSpeed(MethodInfo * method)	96
-#[skyline::hook(offset = 0x2a5e820)]
+#[unity::hook("App", "HubUtil", "get_PlayerMaxSpeed")]
 pub fn get_player_max_speed_hook(method_info: OptionalMethod) -> f32 {
     let speed = call_original!(method_info);
-    unsafe {
-        if CURRENT_FPS == 30 {
-            return speed;
-        } else {
-            // don't let the player go too fast when the game is running at 60fps
-            return speed / 2.0;
-        }
-    }
+
+    // the square root makes our speeds normal: 0.25 -> 0.5
+    return speed_modifier().sqrt() * speed;
 }
+
+#[unity::hook("App", "HubUtil", "get_PlayerAccel")]
+pub fn get_player_accel_hook(method_info: OptionalMethod) -> f32 {
+    let accel = call_original!(method_info);
+
+    return speed_modifier() * accel;
+}
+
+#[unity::hook("App", "HubUtil", "get_PlayerDecel")]
+pub fn get_player_decel_hook(method_info: OptionalMethod) -> f32 {
+    let decel = call_original!(method_info);
+
+    return speed_modifier() * decel;
+}
+
+#[unity::hook("App", "HubUtil", "get_PlayerRotateSpeedRate")]
+pub fn get_player_rotate_speed_rate_hook(method_info: OptionalMethod) -> f32 {
+    let rotate_rate = call_original!(method_info);
+
+    return speed_modifier().sqrt() * rotate_rate;
+}
+
+// #[unity::hook("App", "HubUtil", "get_PlayerDashStopTime")]
+// pub fn get_player_dash_stop_time_hook(method_info: OptionalMethod) -> f32 {
+//     let dash_stop_time = call_original!(method_info);
+
+//     // return speed_modifier() * dash_stop_time;
+//     return dash_stop_time;
+// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#![feature(lazy_cell)]
+#![feature(ptr_sub_ptr)]
+
 use fps_config::fps_settings_callback;
 
 pub mod fps_config;
@@ -14,7 +17,11 @@ pub fn main() {
     cobapi::install_global_game_setting(fps_settings_callback);
     skyline::install_hooks!(
         fps_hooks::vsync_count_hook,
-        fps_hooks::get_player_max_speed_hook
+        fps_hooks::get_player_max_speed_hook,
+        fps_hooks::get_player_accel_hook,
+        fps_hooks::get_player_decel_hook,
+        fps_hooks::get_player_rotate_speed_rate_hook
+        // fps_hooks::get_player_dash_stop_time_hook
     );
     println!(
         "{}",


### PR DESCRIPTION
- Uses various unity hooks to adjust the speed of the player in hubs.
- Changed vsync_count_hook() to potentially support more fps settings in the future